### PR TITLE
清理不必要的 DDG 请求与 CSS 链接

### DIFF
--- a/app.json
+++ b/app.json
@@ -164,5 +164,6 @@
       "description": "[CONFIG] Custom predefined args (e.g. 'site:xxx.com')",
       "value": "",
       "required": false
+    }
   }
 }

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -96,8 +96,9 @@ if not os.path.exists(app.config['SESSION_FILE_DIR']):
 # Generate DDG bang filter, and create path if it doesn't exist yet
 if not os.path.exists(app.config['BANG_PATH']):
     os.makedirs(app.config['BANG_PATH'])
-if not os.path.exists(app.config['BANG_FILE']):
-    gen_bangs_json(app.config['BANG_FILE'])
+# DDG cannot be accessed in Mainland China, this statement raises exception
+# if not os.path.exists(app.config['BANG_FILE']):
+#     gen_bangs_json(app.config['BANG_FILE'])
 
 # Build new mapping of static files for cache busting
 if not os.path.exists(app.config['BUILD_FOLDER']):

--- a/app/routes.py
+++ b/app/routes.py
@@ -26,7 +26,8 @@ from requests import exceptions, get
 from requests.models import PreparedRequest
 
 # Load DDG bang json files only on init
-bang_json = json.load(open(app.config['BANG_FILE']))
+# bang_json = json.load(open(app.config['BANG_FILE'], encoding='utf-8'))
+bang_json = {}
 
 # Check the newest version of WHOOGLE
 update = bsoup(get(app.config['RELEASES_URL']).text, 'html.parser')

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -22,39 +22,8 @@
     <link rel="search" href="opensearch.xml" type="application/opensearchdescription+xml" title="Whoogle Search">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="{{ cb_url('logo.css') }}">
-    {% if config.theme %}
-        {% if config.theme == 'system' %}
-            <style>
-                @import "{{ cb_url('light-theme.css') }}" screen;
-                @import "{{ cb_url('dark-theme.css') }}" screen and (prefers-color-scheme: dark);
-            </style>
-        {% else %}
-            <link rel="stylesheet" href="{{ cb_url(config.theme + '-theme.css') }}"/>
-        {% endif %}
-    {% else %}
-        <link rel="stylesheet" href="{{ cb_url(('dark' if config.dark else 'light') + '-theme.css') }}"/>
-    {% endif %}
     <link rel="stylesheet" href="{{ cb_url('main.css') }}">
-    <noscript>
-        <style>
-            #main {
-                display: inherit !important;
-            }
-
-            .content {
-                max-height: 400px;
-                padding: 18px;
-                border-radius: 10px;
-                overflow-y: scroll;
-            }
-
-            .collapsible {
-                display: none;
-            }
-        </style>
-    </noscript>
-    <style>{{ config.style }}</style>
-    <title>Whoogle Search</title>
+    <title>A岛云搜索 | Powered by Whoogle Search</title>
 </head>
 <body id="main">
 <div class="search-container">

--- a/app/utils/bangs.py
+++ b/app/utils/bangs.py
@@ -16,10 +16,12 @@ def gen_bangs_json(bangs_file: str) -> None:
     """
     try:
         # Request full list from DDG
-        r = requests.get(DDG_BANGS)
+        r = requests.get(DDG_BANGS, timeout=1)
         r.raise_for_status()
     except requests.exceptions.HTTPError as err:
-        raise SystemExit(err)
+        print("DuckDuckGo cannot be accessed")
+        return
+        # raise SystemExit(err)
 
     # Convert to json
     data = json.loads(r.text)
@@ -34,7 +36,7 @@ def gen_bangs_json(bangs_file: str) -> None:
             'suggestion': bang_command + ' (' + row['s'] + ')'
         }
 
-    json.dump(bangs_data, open(bangs_file, 'w'))
+    json.dump(bangs_data, open(bangs_file, 'w', encoding='utf-8'))
 
 
 def resolve_bang(query: str, bangs_dict: dict) -> str:

--- a/run
+++ b/run
@@ -24,7 +24,7 @@ if [[ "$SUBDIR" == "test" ]]; then
     pytest -sv
 else
     mkdir -p "$STATIC_FOLDER"
-    python3 -um app \
+    python -um app \
       --host "${ADDRESS:-0.0.0.0}" \
       --port "${PORT:-"${EXPOSE_PORT:-5000}"}"
 fi

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,9 @@
 import os
 import setuptools
 
-long_description = open('README.md', 'r').read()
+long_description = open('README.md', 'r', encoding='utf-8').read()
 
-requirements = list(open('requirements.txt', 'r'))
+requirements = list(open('requirements.txt', 'r', encoding='utf-8'))
 
 optional_dev_tag = ''
 if os.getenv('DEV_BUILD'):


### PR DESCRIPTION
本地不挂梯子 host 的话，DuckDuckGo 的请求会超时。
据排查，是在 __init__.py 中为了初始化 DDG 风格的 bang 表（我也不知道是什么东西）而发起的请求，看上去完全可以砍掉，遂注释掉。

删掉了 app/templates/index.html 里对于特定主题样式的 CSS 链接。
据排查，该链接未能正确引用到存在的 CSS 文件，其请求被重定向到了根目录下，MIME 不匹配的同时造成无限重定向，故而阻塞。删掉了之后就好了。